### PR TITLE
Update ts-node to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "ts-loader": "^9.0.0",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.0.0",
     "typedoc": "^0.20.34",
     "typedoc-plugin-cname": "^1.0.1",
     "typescript": "^4.2.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cie.js",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
   "description": "Node wrapper around CIE.sh.",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,6 +542,26 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.7.tgz#1eb1de36c73478a2479cc661ef5af1c16d86d606"
+  integrity sha512-aBvUmXLQbayM4w3A8TrjwrXs4DZ8iduJnuJLLRGdkWlyakCf1q6uHZJBzXoRA/huAEknG5tcUyQxN3A+In5euQ==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.7.tgz#677bd9117e8164dc319987dd6ff5fc1ba6fbf18b"
+  integrity sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.0.tgz#5bd046e508b1ee90bc091766758838741fdefd6e"
+  integrity sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ==
+
+"@tsconfig/node16@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.1.tgz#a6ca6a9a0ff366af433f42f5f0e124794ff6b8f1"
+  integrity sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
@@ -4107,11 +4127,15 @@ ts-loader@^9.0.0:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
-ts-node@^9.1.1:
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
-  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+ts-node@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.0.0.tgz#05f10b9a716b0b624129ad44f0ea05dac84ba3be"
+  integrity sha512-ROWeOIUvfFbPZkoDis0L/55Fk+6gFQNZwwKPLinacRl6tsxstTF1DbAcLKkovwnpKMVvOMHP1TIbnwXwtLg1gg==
   dependencies:
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.1"
     arg "^4.1.0"
     create-require "^1.1.0"
     diff "^4.0.1"


### PR DESCRIPTION
## Version **10.0.0** of **ts-node** was just published.

* Package: [repository](https://github.com/TypeStrong/ts-node.git), [npm](https://www.npmjs.com/package/ts-node)
* Current Version: 9.1.1
* Dev: true
* [compare 9.1.1 to 10.0.0 diffs](https://github.com/TypeStrong/ts-node/compare/v9.1.1...v10.0.0)

The version(`10.0.0`) is **not covered** by your current version range(`^9.1.1`).

<details>
<summary>Release Notes</summary>
<h1></h1>
<p>Questions about this release?  Ask in the official discussion thread: <a href="https://github.com/redpeacock78/cie.js/issues/1337">#1337</a></p>
<p>*Breaking changes are prefixed with <strong>[BREAKING]*</strong></p>
<p><strong>Added</strong></p>
<ul>
<li>Adds <code>--show-config</code> to log the resolved configuration (<a href="https://typestrong.org/ts-node/docs/troubleshooting#understanding-configuration">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/1100">#1100</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1243">#1243</a>)</li>
<li>Bundle and re-export <a href="https://github.com/tsconfig/node"><strong>@tsconfig/node</strong></a>* configurations for convenience (<a href="https://typestrong.org/ts-node/docs/configuration#tsconfigbases">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/1202">#1202</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1236">#1236</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1313">#1313</a>)</li>
<li>Default to appropriate <a href="https://github.com/tsconfig/node"><strong>@tsconfig/node</strong></a>* configuration based on node and typescript versions (<a href="https://typestrong.org/ts-node/docs/configuration#default-config">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/1202">#1202</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1236">#1236</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1313">#1313</a>)</li>
<li>Automatically reference <a href="https://github.com/types/node"><strong>@types/node</strong></a>; use globally-installed <a href="https://github.com/types/node"><strong>@types/node</strong></a> if not locally installed (<a href="https://github.com/redpeacock78/cie.js/issues/1240">#1240</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1257">#1257</a>)</li>
<li>Add <code>swc</code> integration and new <code>--transpiler</code> option to use third-party transpilers for a massive speed boost on large codebases (<a href="https://typestrong.org/ts-node/docs/transpilers">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/779">#779</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1160">#1160</a>)</li>
<li>Add <code>scopeDir</code> API option (<a href="https://typestrong.org/ts-node/api/interfaces/RegisterOptions.html#scopeDir">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
<li>Add <code>projectSearchDir</code> API option (<a href="https://typestrong.org/ts-node/api/interfaces/RegisterOptions.html#projectSearchDir">docs</a>) (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
<li>Add <code>--cwd-mode</code> and <code>ts-node-cwd</code> to resolve config file relative to cwd, not entrypoint script (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
</ul>
<p><strong>Changed</strong></p>
<ul>
<li>
<p><strong>[BREAKING]</strong> Make <code>--script-mode</code> default behavior; resolve tsconfig relative to entrypoint script instead of cwd (<a href="https://github.com/redpeacock78/cie.js/issues/949">#949</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1197">#1197</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</p>
<ul>
<li>In most cases this change will have no noticeable effect</li>
<li>Primarily benefits portable shell scripts on your <code>$PATH</code>, because <code>ts-node</code> will respect the script's local <code>tsconfig.json</code></li>
<li>Use <code>--cwd-mode</code> or <code>ts-node-cwd</code> if you need legacy behavior</li>
</ul>
</li>
<li><strong>[BREAKING]</strong> <code>ignore</code> rules evaluate relative to <code>tsconfig.json</code> directory, otherwise <code>cwd</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
<li><strong>[BREAKING]</strong> Remove support for node 10.  Minimum supported version is node 12 (<a href="https://github.com/redpeacock78/cie.js/issues/1312">#1312</a>)</li>
<li>
<p>Rename <code>--dir</code> to <code>--cwd</code>; rename <code>TS_NODE_DIR</code> to <code>TS_NODE_CWD</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</p>
<ul>
<li><code>--dir</code> and <code>TS_NODE_DIR</code> are deprecated but still parsed for backwards-compatibility</li>
<li><code>--dir</code> effectively changed the working directory of <code>ts-node</code>; renaming makes this behavior more obvious</li>
</ul>
</li>
</ul>
<p><strong>Deprecated</strong></p>
<ul>
<li>Deprecate <code>TS_NODE_SCOPE</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
<li>Deprecate <code>--dir</code> and <code>TS_NODE_DIR</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
</ul>
<p><strong>Removed</strong></p>
<ul>
<li>
<p><strong>[BREAKING]</strong> Internal APIs removed from type declarations (<a href="https://github.com/redpeacock78/cie.js/issues/1242">#1242</a>)</p>
<ul>
<li>Removed <code>DEFAULTS</code>, <code>normalizeSlashes</code>, <code>parse</code>, <code>split</code></li>
<li>No features were removed</li>
<li>This will only affect consumers of <code>ts-node</code>'s programmatic API</li>
</ul>
</li>
</ul>
<p><strong>Fixed</strong></p>
<ul>
<li>
<p><strong>[BREAKING]</strong> Fix <a href="https://github.com/redpeacock78/cie.js/issues/1229">#1229</a> and <a href="https://github.com/redpeacock78/cie.js/issues/1235">#1235</a>: always throw <code>ERR_REQUIRE_ESM</code> when attempting to execute ESM as CJS, even when not using <code>--loader ts-node/esm</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1232">#1232</a>)</p>
<ul>
<li>This aligns our behavior with vanilla <code>node</code></li>
</ul>
</li>
<li>
<p><strong>[BREAKING]</strong> Fix <a href="https://github.com/redpeacock78/cie.js/issues/1225">#1225</a>: <code>compiler</code> is loaded relative to <code>tsconfig.json</code> instead of entrypoint script (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</p>
<ul>
<li>In most cases this change will have no noticable effect</li>
</ul>
</li>
<li>Fix <a href="https://github.com/redpeacock78/cie.js/issues/1217">#1217</a>: REPL not always using passed stdout and stderr (<a href="https://github.com/redpeacock78/cie.js/issues/1224">#1224</a>)</li>
<li>Fix <a href="https://github.com/redpeacock78/cie.js/issues/1220">#1220</a>: <code>ts-node ./index</code> may execute the wrong file extension because tsconfig search poisons the <code>require.resolve</code> cache (<a href="https://github.com/redpeacock78/cie.js/issues/1155">#1155</a>)</li>
<li>Fix <a href="https://github.com/redpeacock78/cie.js/issues/1322">#1322</a>: Sourcemaps fail for filenames with spaces or other characters which are percent-encoded in URLs (<a href="https://github.com/redpeacock78/cie.js/issues/1160">#1160</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1330">#1330</a>)</li>
<li>Fix <a href="https://github.com/redpeacock78/cie.js/issues/1331">#1331</a>: Resolution of node builtin modules in ESM loader fails on node >=12.20.0, &#x3C;13 (<a href="https://github.com/redpeacock78/cie.js/issues/1332">#1332</a>)</li>
</ul>
<p><strong>Docs</strong></p>
<ul>
<li>
<p>New documentation website: <a href="https://typestrong.org/ts-node">https://typestrong.org/ts-node</a></p>
<ul>
<li>README is generated to match the website</li>
<li>Added page explaining CommonJS vs ESM</li>
<li>Added page with Performance advice</li>
<li>Added Troubleshooting page</li>
<li>Organized and added to "Recipes" section with third-party tool integrations</li>
<li>Added TypeDoc-generated API docs</li>
<li>Work was spread across multiple tickets: <a href="https://github.com/redpeacock78/cie.js/issues/1207">#1207</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1213">#1213</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1221">#1221</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1228">#1228</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1244">#1244</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1250">#1250</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1294">#1294</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1295">#1295</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1296">#1296</a>, <a href="https://github.com/redpeacock78/cie.js/issues/1297">#1297</a></li>
<li>
<p>Thanks to these contributors for PRs which improved our documentation</p>
<ul>
<li>add troubleshooting tip for syntax errors (<a href="https://github.com/redpeacock78/cie.js/issues/1201">#1201</a>) <a href="https://github.com/jedwards1211"><strong>@jedwards1211</strong></a></li>
<li>Clarify handling of tsx/jsx file extensions (<a href="https://github.com/redpeacock78/cie.js/issues/1179">#1179</a>) <a href="https://github.com/NaridaL"><strong>@NaridaL</strong></a></li>
</ul>
</li>
</ul>
</li>
<li>Added <code>CONTRIBUTING.md</code> to document the codebase and our development workflow</li>
</ul>
<p><a href="https://github.com/TypeStrong/ts-node/compare/v9.1.1...v10.0.0">https://github.com/TypeStrong/ts-node/compare/v9.1.1...v10.0.0</a>
<a href="https://github.com/TypeStrong/ts-node/milestone/1">https://github.com/TypeStrong/ts-node/milestone/1</a></p>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: