### PR TITLE
Update typedoc to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cie.js",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
   "description": "Node wrapper around CIE.sh.",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ts-jest": "^27.0.0",
     "ts-loader": "^9.0.0",
     "ts-node": "^10.0.0",
-    "typedoc": "^0.20.34",
+    "typedoc": "^0.21.0",
     "typedoc-plugin-cname": "^1.0.1",
     "typescript": "^4.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,11 +997,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 babel-jest@^27.0.1:
   version "27.0.1"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.0.1.tgz#9f1c4571ac17a39e599d1325dcaf53a274261df4"
@@ -1222,11 +1217,6 @@ colorette@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
-
-colors@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
-  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.8:
   version "1.0.8"
@@ -1672,16 +1662,6 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1729,10 +1709,22 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1772,7 +1764,7 @@ globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -1890,11 +1882,6 @@ inherits@2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
-
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 is-ci@^3.0.0:
   version "3.0.0"
@@ -2492,15 +2479,6 @@ json5@2.x, json5@^2.1.2:
   dependencies:
     minimist "^1.2.5"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -2591,10 +2569,10 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-marked@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-2.0.1.tgz#5e7ed7009bfa5c95182e4eb696f85e948cefcee3"
-  integrity sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==
+marked@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.1.tgz#b7c27f520fc4de0ddd049d9b4be3b04e06314923"
+  integrity sha512-5XFS69o9CzDpQDSpUYC+AN2xvq8yl1EGa5SG/GI1hP78/uTeo3PDfiDNmsUyiahpyhToDDJhQk7fNtJsga+KVw==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -2908,13 +2886,6 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
-
 regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
@@ -2947,7 +2918,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.6, resolve@^1.20.0:
+resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -3014,15 +2985,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
 
 shiki@^0.9.3:
   version "0.9.3"
@@ -3342,7 +3304,7 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typedoc-default-themes@^0.12.9:
+typedoc-default-themes@^0.12.10:
   version "0.12.10"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz#614c4222fe642657f37693ea62cad4dafeddf843"
   integrity sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==
@@ -3352,22 +3314,20 @@ typedoc-plugin-cname@^1.0.1:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-cname/-/typedoc-plugin-cname-1.0.1.tgz#b555c4e79317f86521f2eec887db8d65b247408b"
   integrity sha512-f97SS5RzDCVBa7Frg1VketIMAkEl3OTvBs9wM8lLEkJVWCIG2yXnszglA82on39gFwQ1tyq8tiuxRgb4569GpA==
 
-typedoc@^0.20.34:
-  version "0.20.34"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.34.tgz#763c4e1ebef55fd4f71a27f0f02249926107021a"
-  integrity sha512-es+N/KyGPcHl9cAuYh1Z5m7HzwcmfNLghkmb2pzGz7HRDS5GS2uA3hu/c2cv4gCxDsw8pPUPCOvww+Hzf48Kug==
+typedoc@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.21.0.tgz#d35dd69b1566032cd893f4f6f21f37156f5f78d2"
+  integrity sha512-InmPBVlpOXptIkg/WnsQhbGYhv9cuDh/cRACUSautQ0QwcJPLAK2kHcfP0Pld6z/NiDvHc159fMq2qS+b/ALUw==
   dependencies:
-    colors "^1.4.0"
-    fs-extra "^9.1.0"
+    glob "^7.1.7"
     handlebars "^4.7.7"
     lodash "^4.17.21"
     lunr "^2.3.9"
-    marked "^2.0.1"
+    marked "^2.1.1"
     minimatch "^3.0.0"
     progress "^2.0.3"
-    shelljs "^0.8.4"
     shiki "^0.9.3"
-    typedoc-default-themes "^0.12.9"
+    typedoc-default-themes "^0.12.10"
 
 typescript@^4.2.3:
   version "4.2.3"
@@ -3383,11 +3343,6 @@ universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
## Version **0.21.0** of **typedoc** was just published.

* Package: [repository](https://github.com/TypeStrong/TypeDoc.git), [npm](https://www.npmjs.com/package/typedoc)
* Current Version: 0.20.34
* Dev: true
* [compare 0.20.34 to 0.21.0 diffs](https://github.com/TypeStrong/typedoc/compare/v0.20.34...v0.21.0)

The version(`0.21.0`) is **not covered** by your current version range(`^0.20.34`).

<details>
<summary>Release Notes</summary>
<h1>v0.21.0</h1>
<h3>Breaking Changes</h3>
<ul>
<li>Drop support for Node v10 (<a href="https://github.com/TypeStrong/typedoc/commit/dc8416a83f1dfbc35a1c26788b344c3876eb8196">dc8416a</a>)</li>
<li>Drop support for TypeScript 3.9 (<a href="https://github.com/TypeStrong/typedoc/commit/5d455396d764f3ff4066b8fbe0c9767e30e03b56">5d45539</a>)</li>
<li>Remove disableAliases option introduced in 0.20.37 (<a href="https://github.com/TypeStrong/typedoc/commit/ec18bb0ee3ab62a693707e9a6ec4cdbc0abd2cec">ec18bb0</a>)</li>
<li>Paths in config files will now be resolved relative to the config file's directory (<a href="https://github.com/TypeStrong/typedoc/commit/3f39508e681bbd887235ac4a942e83f441fc1bde">3f39508</a>)</li>
<li>Plugins are now passed Application directly (<a href="https://github.com/TypeStrong/typedoc/commit/22df5746dc8bf7df0a26ff47e1f1d82737461f05">22df574</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1598">#1598</a></li>
</ul>
<h3>Features</h3>
<ul>
<li>Improve monorepos by adding support for TS entry points via <code>--packages</code> (<a href="https://github.com/redpeacock78/cie.js/issues/1596">#1596</a>) (<a href="https://github.com/TypeStrong/typedoc/commit/6d215dffa42e23e4182945d938fd3be261351c61">6d215df</a>)</li>
<li>Support for monorepos (<a href="https://github.com/TypeStrong/typedoc/commit/15c05527805e12f8615811c81ddcc1a2ad81b58b">15c0552</a>)</li>
<li>Support for TypeScript 4.3 (<a href="https://github.com/TypeStrong/typedoc/commit/432008c8dbda7ea8c6b9115f0302843593f54911">432008c</a>)</li>
<li>Add support for sorting reflections based on user criteria (<a href="https://github.com/TypeStrong/typedoc/commit/e1254843bcd34202d7277ef0e311b56cf9db869d">e125484</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/112">#112</a></li>
<li>Add the <code>--treatWarningsAsErrors</code> option (<a href="https://github.com/TypeStrong/typedoc/commit/58f1bac81b594123a3ed0fdb5d970f276d8ada9a">58f1bac</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1568">#1568</a></li>
<li>The <code>--exclude</code> option will now remove symbols re-exported from excluded files (<a href="https://github.com/TypeStrong/typedoc/commit/bb5a5ae4c538f9359c7bf428d344b6769bf36641">bb5a5ae</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1578">#1578</a></li>
</ul>
<h3>Bug Fixes</h3>
<ul>
<li>Correctly handle comments on function type aliases (<a href="https://github.com/TypeStrong/typedoc/commit/1b1cd140828be02cbcac6214ade7448beb1e0eee">1b1cd14</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/799">#799</a></li>
<li>Setters should always have a <code>void</code> return type (<a href="https://github.com/TypeStrong/typedoc/commit/1dc56591b9b230c95c57b07c4679616299f2323e">1dc5659</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1215">#1215</a></li>
<li>Pick up doc comments for properties declared within a class's constructor when documenting JavaScript (<a href="https://github.com/TypeStrong/typedoc/commit/700d4130daabc127a72cf92f0f77a514e340290d">700d413</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1255">#1255</a></li>
<li>Inherit comments from parent methods (<a href="https://github.com/TypeStrong/typedoc/commit/d5bb930c880e5a6fa0e2903fc4dec6edfc865333">d5bb930</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1580">#1580</a></li>
<li>Correct handling for intentionally broken references (<a href="https://github.com/TypeStrong/typedoc/commit/5d581b0c2d6abdab3aede4c46e33da4f12c1e467">5d581b0</a>)</li>
<li>Inheritance from multiple <code>Partial&#x3C;T></code> types was incorrectly converted (<a href="https://github.com/TypeStrong/typedoc/commit/4aad444e7995719f2988346e0e1bc6a836f48c20">4aad444</a>), closes <a href="https://github.com/TypeStrong/typedoc/issues/1579">#1579</a></li>
</ul>
<h3>Thanks!</h3>
<p>The support for monorepos was made possible by <a href="https://github.com/efokschaner"><strong>@efokschaner</strong></a> and <a href="https://github.com/Lhoerion"><strong>@Lhoerion</strong></a>. It wouldn't have happened without their contributions. Thank you!</p>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: