### PR TITLE
Update @typescript-eslint/eslint-plugin, @typescript-eslint/parser to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cie.js",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "main": "dist/main.js",
   "types": "dist/main.d.ts",
   "description": "Node wrapper around CIE.sh.",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@types/jest": "^27.0.0",
     "@types/node": "^16.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.19.0",
-    "@typescript-eslint/parser": "^4.19.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,10 +759,10 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
-"@types/json-schema@^7.0.3":
-  version "7.0.7"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
-  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+"@types/json-schema@^7.0.7":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
+  integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
 "@types/node@*":
   version "14.14.35"
@@ -803,75 +803,75 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz#56f8da9ee118fe9763af34d6a526967234f6a7f0"
-  integrity sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==
+"@typescript-eslint/eslint-plugin@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.0.0.tgz#ecc7cc69d1e6f342beb6ea9cf9fbc02c97a212ac"
+  integrity sha512-T6V6fCD2U0YesOedvydTnrNtsC8E+c2QzpawIpDdlaObX0OX5dLo7tLU5c64FhTZvA1Xrdim+cXDI7NPsVx8Cg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.19.0"
-    "@typescript-eslint/scope-manager" "4.19.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "5.0.0"
+    "@typescript-eslint/scope-manager" "5.0.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    lodash "^4.17.15"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    ignore "^5.1.8"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.19.0.tgz#9ca379919906dc72cb0fcd817d6cb5aa2d2054c6"
-  integrity sha512-9/23F1nnyzbHKuoTqFN1iXwN3bvOm/PRIXSBR3qFAYotK/0LveEOHr5JT1WZSzcD6BESl8kPOG3OoDRKO84bHA==
+"@typescript-eslint/experimental-utils@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-5.0.0.tgz#c7d7e67443dfb9fd93a5d060fb72c9e9b5638bbc"
+  integrity sha512-Dnp4dFIsZcPawD6CT1p5NibNUQyGSEz80sULJZkyhyna8AEqArmfwMwJPbmKzWVo4PabqNVzHYlzmcdLQWk+pg==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "5.0.0"
+    "@typescript-eslint/types" "5.0.0"
+    "@typescript-eslint/typescript-estree" "5.0.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.19.0.tgz#4ae77513b39f164f1751f21f348d2e6cb2d11128"
-  integrity sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==
+"@typescript-eslint/parser@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.0.0.tgz#50d1be2e0def82d73e863cceba74aeeac9973592"
+  integrity sha512-B6D5rmmQ14I1fdzs71eL3DAuvnPHTY/t7rQABrL9BLnx/H51Un8ox1xqYAchs0/V2trcoyxB1lMJLlrwrJCDgw==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
-    debug "^4.1.1"
+    "@typescript-eslint/scope-manager" "5.0.0"
+    "@typescript-eslint/types" "5.0.0"
+    "@typescript-eslint/typescript-estree" "5.0.0"
+    debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.19.0.tgz#5e0b49eca4df7684205d957c9856f4e720717a4f"
-  integrity sha512-GGy4Ba/hLXwJXygkXqMzduqOMc+Na6LrJTZXJWVhRrSuZeXmu8TAnniQVKgj8uTRKe4igO2ysYzH+Np879G75g==
+"@typescript-eslint/scope-manager@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.0.0.tgz#aea0fb0e2480c1169a02e89d9005ac3f2835713f"
+  integrity sha512-5RFjdA/ain/MDUHYXdF173btOKncIrLuBmA9s6FJhzDrRAyVSA+70BHg0/MW6TE+UiKVyRtX91XpVS0gVNwVDQ==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
+    "@typescript-eslint/types" "5.0.0"
+    "@typescript-eslint/visitor-keys" "5.0.0"
 
-"@typescript-eslint/types@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.19.0.tgz#5181d5d2afd02e5b8f149ebb37ffc8bd7b07a568"
-  integrity sha512-A4iAlexVvd4IBsSTNxdvdepW0D4uR/fwxDrKUa+iEY9UWvGREu2ZyB8ylTENM1SH8F7bVC9ac9+si3LWNxcBuA==
+"@typescript-eslint/types@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.0.0.tgz#25d93f6d269b2d25fdc51a0407eb81ccba60eb0f"
+  integrity sha512-dU/pKBUpehdEqYuvkojmlv0FtHuZnLXFBn16zsDmlFF3LXkOpkAQ2vrKc3BidIIve9EMH2zfTlxqw9XM0fFN5w==
 
-"@typescript-eslint/typescript-estree@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.19.0.tgz#8a709ffa400284ab72df33376df085e2e2f61147"
-  integrity sha512-3xqArJ/A62smaQYRv2ZFyTA+XxGGWmlDYrsfZG68zJeNbeqRScnhf81rUVa6QG4UgzHnXw5VnMT5cg75dQGDkA==
+"@typescript-eslint/typescript-estree@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.0.0.tgz#bc20f413c6e572c7309dbe5fa3be027984952af3"
+  integrity sha512-V/6w+PPQMhinWKSn+fCiX5jwvd1vRBm7AX7SJQXEGQtwtBvjMPjaU3YTQ1ik2UF1u96X7tsB96HMnulG3eLi9Q==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/visitor-keys" "4.19.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
+    "@typescript-eslint/types" "5.0.0"
+    "@typescript-eslint/visitor-keys" "5.0.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.19.0.tgz#cbea35109cbd9b26e597644556be4546465d8f7f"
-  integrity sha512-aGPS6kz//j7XLSlgpzU2SeTqHPsmRYxFztj2vPuMMFJXZudpRSehE3WCV+BaxwZFvfAqMoSd86TEuM0PQ59E/A==
+"@typescript-eslint/visitor-keys@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.0.0.tgz#b789f7cd105e59bee5c0983a353942a5a48f56df"
+  integrity sha512-yRyd2++o/IrJdyHuYMxyFyBhU762MRHQ/bAGQeTnN3pGikfh+nEmM61XTqaDH1XDp53afZ+waXrk0ZvenoZ6xw==
   dependencies:
-    "@typescript-eslint/types" "4.19.0"
-    eslint-visitor-keys "^2.0.0"
+    "@typescript-eslint/types" "5.0.0"
+    eslint-visitor-keys "^3.0.0"
 
 abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
@@ -1291,7 +1291,7 @@ debug@4, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debug@^4.3.2:
+debug@^4.3.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -1443,7 +1443,7 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-scope@^5.0.0:
+eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -1459,24 +1459,12 @@ eslint-scope@^6.0.0:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-utils@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
-  dependencies:
-    eslint-visitor-keys "^1.1.0"
-
 eslint-utils@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
   version "2.0.0"
@@ -1794,10 +1782,10 @@ globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.1:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
-  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+globby@^11.0.3:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -1874,7 +1862,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -2570,7 +2558,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2925,12 +2913,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-regexpp@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
-  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
-
-regexpp@^3.2.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -3001,7 +2984,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -3277,7 +3260,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tsutils@^3.17.1:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
## Version **5.0.0** of **@typescript-eslint/eslint-plugin** was just published.

* Package: [repository](https://github.com/typescript-eslint/typescript-eslint.git), [npm](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
* Current Version: 4.19.0
* Dev: true
* [compare 4.19.0 to 5.0.0 diffs](https://github.com/typescript-eslint/typescript-eslint/compare/v4.19.0...v5.0.0)

The version(`5.0.0`) is **not covered** by your current version range(`^4.19.0`).

<details>
<summary>Release Notes</summary>
<h1>v5.0.0</h1>
<h1><a href="https://github.com/typescript-eslint/typescript-eslint/compare/v4.33.0...v5.0.0">5.0.0</a> (2021-10-11)</h1>
<h2>Breaking Release Notes</h2>
<h3>All Packages</h3>
<ul>
<li>Support for ESLint v8 (see individual packages for relevant breaking changes).</li>
<li>
<p>Drop support for Node v10 - required node version is now <code>^12.22.0 || ^14.17.0 || >=16.0.0</code>.</p>
<ul>
<li>Node v10 was EOL'd in April 2021, and ESLint v8 dropped support for it too.</li>
</ul>
</li>
<li>
<p>Drop Support for ESLint v5</p>
<ul>
<li>ESLint v5 is now 3 years old - why are you still using it? Upgrade to at least ESLint v6.</li>
</ul>
</li>
</ul>
<h3>ESLint-Plugin</h3>
<ul>
<li>Changes to the recommended rule set - see <a href="https://github.com/redpeacock78/cie.js/issues/3746">#3746</a></li>
<li>
<p>[ban-types] remove <code>object</code> from the default ban list</p>
<ul>
<li>This has been a point of contention for a while - I originally added it because TS currently makes it impossible to narrow the type nicely. However there ultimately isn't a good alternative to this type for many usecases. As such we're removing the default ban. If you want to continue banning it, <a href="https://gist.github.com/bradzacher/8b74ad4bdcd75f4c0ccdf855a2f0c03d">you can configure the rule to do so</a>.</li>
</ul>
</li>
<li>
<p>[comma-dangle] align schema with ESLint v8</p>
<ul>
<li>Should be pretty transparent unless you were using an invalid config.</li>
</ul>
</li>
<li>[explicit-member-accessibility] now checks abstract members</li>
<li>
<p>[member-ordering] add support for getters and setters</p>
<ul>
<li>This will likely cause your codebase's sort orders to change if you're using the default config.</li>
</ul>
</li>
<li>
<p>[no-unused-vars-experimental] rule has been deleted</p>
<ul>
<li>You should instead use <a href="https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md"><code>@typescript-eslint/no-unused-vars</code></a> instead! It has had full and awesome support for TypeScript since v4.9.0 - and it doesn't require type information!</li>
</ul>
</li>
</ul>
<h3>Experimental-Utils:</h3>
<ul>
<li>
<p>Remove <code>SourceCode#getComments</code> API from ESLint types.</p>
<ul>
<li>This API was deprecated in ESLint v4, and its usage will error in ESLint v8.</li>
</ul>
</li>
<li>
<p>Support ESLint v8:</p>
<ul>
<li><code>CLIEngine</code> is now conditionally <code>undefined</code>. It was deprecated in v7 and removed in v8. If you're still using it, you should upgrade to the <code>ESLint</code> API.</li>
<li>Remove <code>meta.docs.category</code>. ESLint has removed this from their core rules as it wasn't ever very useful and was always poorly done. We have followed suit and removed it from our types and our rules.</li>
</ul>
</li>
</ul>
<h3>TypeScript-ESTree / AST-Spec</h3>
<ul>
<li>
<p>Change <code>.source</code> of <code>ExportNamedDeclaration</code>, <code>ExportAllDeclaration</code> and <code>ImportDeclaration</code> to <code>StringLiteral</code> and add parse-time errors.</p>
<ul>
<li>This ensures we're aligned with ESTree and producing the correct AST.</li>
</ul>
</li>
<li>
<p>Remove <code>TSParenthesizedType</code> node.</p>
<ul>
<li>This node was added when this project was first created because the TS-AST includes this node. However it ultimately conveys no actual AST meaning (just like parentheses in non-type code). Babel removed this node earlier this year.</li>
<li>We expect rules will continue to "just work". In a lot of cases rules will work <em>better</em> as they no longer need manual checks to "look past" the useless node.</li>
</ul>
</li>
<li>
<p>Remove legacy option <code>useJSXTextNode</code>.</p>
<ul>
<li>This option was added for compatibility between different ASTs a very long time ago - but all ASTs have converged on using <code>JSXText</code> - so you should be using that too.</li>
</ul>
</li>
<li>
<p>Align class features AST with ESTree. This aligns with ESLint v8.</p>
<ul>
<li><code>ClassProperty</code> is now called <code>PropertyDefinition</code></li>
<li><code>TSAbstractClassProperty</code> is now called <code>TSAbstractPropertyDefinition</code></li>
</ul>
</li>
<li>
<p><code>TSAbstractPropertyDefinition.value</code> is now always <code>null</code>.</p>
<ul>
<li>It never made sense that this was allowed, and TS4.4 has now made this invalid.</li>
</ul>
</li>
<li>
<p>Add full support for <code>PrivateIdentifier</code> (<code>#private</code> class members)</p>
<ul>
<li>Previously we did not officially support them and emitted an "unstable" AST.</li>
<li>This will allow the community to build lint rules specifically targeting <code>#private</code> members.</li>
</ul>
</li>
<li>Rename <code>LineAndColumnData</code> to <code>Position</code> (aligns naming with the ESTree spec docs)</li>
</ul>
<h3>Scope-Manager</h3>
<ul>
<li>
<p>Class properties with values now create a <code>'class-field-initializer'</code> type scope around their value.</p>
<ul>
<li>This aligns with <code>eslint-scope</code> v6.</li>
</ul>
</li>
</ul>
<hr>
<h2>Raw Changelog</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [explicit-member-accessibility] report <code>TSAbstractPropertyDefinition</code> and <code>TSAbstractMethodDefinition</code> properly (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3901">#3901</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/82016f99b14825c9c60e1f7eb3b4efcc492bba86">82016f9</a>)</li>
<li><strong>eslint-plugin:</strong> update new rules from master (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3840">#3840</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/d88a6b44eedcf9dd59569160570aa118851aa86b">d88a6b4</a>)</li>
<li>update new rules from master (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/b34fb7eb3102ea603bb4aef0dbbf9885b3d47557">b34fb7e</a>)</li>
<li><strong>eslint-plugin:</strong> crash in no-dupe-class-members (v5) (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3813">#3813</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/4b096442f731c0a60926ac0391a4f2c4208aa8d4">4b09644</a>)</li>
<li><strong>experimental-utils:</strong> fix <code>isSetter</code>'s return type (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3975">#3975</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/d2568561d0417fdfbdfd964ad942f9d00434af73">d256856</a>)</li>
<li><strong>typescript-estree:</strong> change <code>source</code> of ExportNamedDeclaration to Literal from Expression (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3763">#3763</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/dc5a0f5104b400f4422b8d67ecfc6cc7a32613a2">dc5a0f5</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>ast-spec:</strong> bring <code>Node</code> objects in line with ESTree (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3771">#3771</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/dd140643b457aa515cc21fcda2b3cd4acc2a1c5c">dd14064</a>)</li>
<li><strong>eslint-plugin:</strong> remove <code>object</code> from <code>ban-types</code>' default types (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3818">#3818</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf">ae3fa90</a>)</li>
<li><strong>eslint-plugin:</strong> removed value from abstract property nodes (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3765">#3765</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/58235241714596b641a1e8b39c569e561e0039b4">5823524</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3748">#3748</a></li>
<li><strong>eslint-plugin:</strong> update recommended configs (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3809">#3809</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/deeb7bb9334d301c6af56aefd37d318231af11ef">deeb7bb</a>)</li>
<li>align class property representation with ESTree (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3806">#3806</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/22fa5c0c4705ed2898f00b7cacc5dd642d859275">22fa5c0</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3430">#3430</a> <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3077">#3077</a></li>
<li><strong>eslint-plugin:</strong> [comma-dangle] align schema with ESLint v8 (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3768">#3768</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0acfafcc655e28dcfc05a5caa567c0d0217ee7ad">0acfafc</a>)</li>
<li><strong>eslint-plugin:</strong> [member-ordering] add support for getters and setters (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3611">#3611</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/e2641246571b69df36cde5cb7bce7c4fffc43f98">e264124</a>)</li>
<li><strong>eslint-plugin:</strong> remove <code>no-unused-vars-experimental</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/79ae03b8adbae2b0a86276711a9c834af01bbb61">79ae03b</a>)</li>
<li><strong>eslint-plugin:</strong> [<code>ban-types</code>] remove <code>object</code> from default options ([<a href="https://github.com/typescript-eslint/typescript-eslint/commit/ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf">ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf</a></li>
<li>remove <code>meta.docs.category</code> from rules (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3800">#3800</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/71c93706e55f5f92a1285102b93c6ab1950c6df4">71c9370</a>)</li>
<li>remove <code>TSParenthesizedType</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3340">#3340</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/c8ee43269faea4c04ec02eaa2b81a0aa6eec5d3e">c8ee432</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3136">#3136</a></li>
<li>support <code>PrivateIdentifier</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3808">#3808</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0eefe5e49d21af3f1e3e2d9a90c2e49929863ac2">0eefe5e</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3430">#3430</a> <a href="https://github.com/typescript-eslint/typescript-eslint/issues/2933">#2933</a></li>
<li><strong>experimental-utils:</strong> extract <code>isNodeOfTypes</code> out of <code>ast-utils</code>' <code>predicates</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3836">#3836</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0cc509b61df248cfb4b42fe64ec800f3cac69c69">0cc509b</a>)</li>
<li><strong>typescript-estree:</strong> remove legacy <code>useJSXTextNode</code> option (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3109">#3109</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/5b84b98fb3cf68d944b7d4e970f39f4e88f0b2d5">5b84b98</a>)</li>
<li>support ESLint v8 (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3737">#3737</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/4ca62aee6681d706e762a8db727541ca204364f2">4ca62ae</a>)</li>
<li><strong>experimental-utils:</strong> remove <code>getComments</code> from <code>ESLint</code> <code>SourceCode</code> types (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3766">#3766</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/165a507970d8e4a0ed12abdd5f0d892f7de83ffe">165a507</a>)</li>
</ul>

</details>


----------------------------------------

## Version **5.0.0** of **@typescript-eslint/parser** was just published.

* Package: [repository](https://github.com/typescript-eslint/typescript-eslint.git), [npm](https://www.npmjs.com/package/@typescript-eslint/parser)
* Current Version: 4.19.0
* Dev: true
* [compare 4.19.0 to 5.0.0 diffs](https://github.com/typescript-eslint/typescript-eslint/compare/v4.19.0...v5.0.0)

The version(`5.0.0`) is **not covered** by your current version range(`^4.19.0`).

<details>
<summary>Release Notes</summary>
<h1>v5.0.0</h1>
<h1><a href="https://github.com/typescript-eslint/typescript-eslint/compare/v4.33.0...v5.0.0">5.0.0</a> (2021-10-11)</h1>
<h2>Breaking Release Notes</h2>
<h3>All Packages</h3>
<ul>
<li>Support for ESLint v8 (see individual packages for relevant breaking changes).</li>
<li>
<p>Drop support for Node v10 - required node version is now <code>^12.22.0 || ^14.17.0 || >=16.0.0</code>.</p>
<ul>
<li>Node v10 was EOL'd in April 2021, and ESLint v8 dropped support for it too.</li>
</ul>
</li>
<li>
<p>Drop Support for ESLint v5</p>
<ul>
<li>ESLint v5 is now 3 years old - why are you still using it? Upgrade to at least ESLint v6.</li>
</ul>
</li>
</ul>
<h3>ESLint-Plugin</h3>
<ul>
<li>Changes to the recommended rule set - see <a href="https://github.com/redpeacock78/cie.js/issues/3746">#3746</a></li>
<li>
<p>[ban-types] remove <code>object</code> from the default ban list</p>
<ul>
<li>This has been a point of contention for a while - I originally added it because TS currently makes it impossible to narrow the type nicely. However there ultimately isn't a good alternative to this type for many usecases. As such we're removing the default ban. If you want to continue banning it, <a href="https://gist.github.com/bradzacher/8b74ad4bdcd75f4c0ccdf855a2f0c03d">you can configure the rule to do so</a>.</li>
</ul>
</li>
<li>
<p>[comma-dangle] align schema with ESLint v8</p>
<ul>
<li>Should be pretty transparent unless you were using an invalid config.</li>
</ul>
</li>
<li>[explicit-member-accessibility] now checks abstract members</li>
<li>
<p>[member-ordering] add support for getters and setters</p>
<ul>
<li>This will likely cause your codebase's sort orders to change if you're using the default config.</li>
</ul>
</li>
<li>
<p>[no-unused-vars-experimental] rule has been deleted</p>
<ul>
<li>You should instead use <a href="https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md"><code>@typescript-eslint/no-unused-vars</code></a> instead! It has had full and awesome support for TypeScript since v4.9.0 - and it doesn't require type information!</li>
</ul>
</li>
</ul>
<h3>Experimental-Utils:</h3>
<ul>
<li>
<p>Remove <code>SourceCode#getComments</code> API from ESLint types.</p>
<ul>
<li>This API was deprecated in ESLint v4, and its usage will error in ESLint v8.</li>
</ul>
</li>
<li>
<p>Support ESLint v8:</p>
<ul>
<li><code>CLIEngine</code> is now conditionally <code>undefined</code>. It was deprecated in v7 and removed in v8. If you're still using it, you should upgrade to the <code>ESLint</code> API.</li>
<li>Remove <code>meta.docs.category</code>. ESLint has removed this from their core rules as it wasn't ever very useful and was always poorly done. We have followed suit and removed it from our types and our rules.</li>
</ul>
</li>
</ul>
<h3>TypeScript-ESTree / AST-Spec</h3>
<ul>
<li>
<p>Change <code>.source</code> of <code>ExportNamedDeclaration</code>, <code>ExportAllDeclaration</code> and <code>ImportDeclaration</code> to <code>StringLiteral</code> and add parse-time errors.</p>
<ul>
<li>This ensures we're aligned with ESTree and producing the correct AST.</li>
</ul>
</li>
<li>
<p>Remove <code>TSParenthesizedType</code> node.</p>
<ul>
<li>This node was added when this project was first created because the TS-AST includes this node. However it ultimately conveys no actual AST meaning (just like parentheses in non-type code). Babel removed this node earlier this year.</li>
<li>We expect rules will continue to "just work". In a lot of cases rules will work <em>better</em> as they no longer need manual checks to "look past" the useless node.</li>
</ul>
</li>
<li>
<p>Remove legacy option <code>useJSXTextNode</code>.</p>
<ul>
<li>This option was added for compatibility between different ASTs a very long time ago - but all ASTs have converged on using <code>JSXText</code> - so you should be using that too.</li>
</ul>
</li>
<li>
<p>Align class features AST with ESTree. This aligns with ESLint v8.</p>
<ul>
<li><code>ClassProperty</code> is now called <code>PropertyDefinition</code></li>
<li><code>TSAbstractClassProperty</code> is now called <code>TSAbstractPropertyDefinition</code></li>
</ul>
</li>
<li>
<p><code>TSAbstractPropertyDefinition.value</code> is now always <code>null</code>.</p>
<ul>
<li>It never made sense that this was allowed, and TS4.4 has now made this invalid.</li>
</ul>
</li>
<li>
<p>Add full support for <code>PrivateIdentifier</code> (<code>#private</code> class members)</p>
<ul>
<li>Previously we did not officially support them and emitted an "unstable" AST.</li>
<li>This will allow the community to build lint rules specifically targeting <code>#private</code> members.</li>
</ul>
</li>
<li>Rename <code>LineAndColumnData</code> to <code>Position</code> (aligns naming with the ESTree spec docs)</li>
</ul>
<h3>Scope-Manager</h3>
<ul>
<li>
<p>Class properties with values now create a <code>'class-field-initializer'</code> type scope around their value.</p>
<ul>
<li>This aligns with <code>eslint-scope</code> v6.</li>
</ul>
</li>
</ul>
<hr>
<h2>Raw Changelog</h2>
<h3>Bug Fixes</h3>
<ul>
<li><strong>eslint-plugin:</strong> [explicit-member-accessibility] report <code>TSAbstractPropertyDefinition</code> and <code>TSAbstractMethodDefinition</code> properly (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3901">#3901</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/82016f99b14825c9c60e1f7eb3b4efcc492bba86">82016f9</a>)</li>
<li><strong>eslint-plugin:</strong> update new rules from master (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3840">#3840</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/d88a6b44eedcf9dd59569160570aa118851aa86b">d88a6b4</a>)</li>
<li>update new rules from master (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/b34fb7eb3102ea603bb4aef0dbbf9885b3d47557">b34fb7e</a>)</li>
<li><strong>eslint-plugin:</strong> crash in no-dupe-class-members (v5) (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3813">#3813</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/4b096442f731c0a60926ac0391a4f2c4208aa8d4">4b09644</a>)</li>
<li><strong>experimental-utils:</strong> fix <code>isSetter</code>'s return type (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3975">#3975</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/d2568561d0417fdfbdfd964ad942f9d00434af73">d256856</a>)</li>
<li><strong>typescript-estree:</strong> change <code>source</code> of ExportNamedDeclaration to Literal from Expression (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3763">#3763</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/dc5a0f5104b400f4422b8d67ecfc6cc7a32613a2">dc5a0f5</a>)</li>
</ul>
<h3>Features</h3>
<ul>
<li><strong>ast-spec:</strong> bring <code>Node</code> objects in line with ESTree (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3771">#3771</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/dd140643b457aa515cc21fcda2b3cd4acc2a1c5c">dd14064</a>)</li>
<li><strong>eslint-plugin:</strong> remove <code>object</code> from <code>ban-types</code>' default types (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3818">#3818</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf">ae3fa90</a>)</li>
<li><strong>eslint-plugin:</strong> removed value from abstract property nodes (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3765">#3765</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/58235241714596b641a1e8b39c569e561e0039b4">5823524</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3748">#3748</a></li>
<li><strong>eslint-plugin:</strong> update recommended configs (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3809">#3809</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/deeb7bb9334d301c6af56aefd37d318231af11ef">deeb7bb</a>)</li>
<li>align class property representation with ESTree (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3806">#3806</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/22fa5c0c4705ed2898f00b7cacc5dd642d859275">22fa5c0</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3430">#3430</a> <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3077">#3077</a></li>
<li><strong>eslint-plugin:</strong> [comma-dangle] align schema with ESLint v8 (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3768">#3768</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0acfafcc655e28dcfc05a5caa567c0d0217ee7ad">0acfafc</a>)</li>
<li><strong>eslint-plugin:</strong> [member-ordering] add support for getters and setters (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3611">#3611</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/e2641246571b69df36cde5cb7bce7c4fffc43f98">e264124</a>)</li>
<li><strong>eslint-plugin:</strong> remove <code>no-unused-vars-experimental</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/79ae03b8adbae2b0a86276711a9c834af01bbb61">79ae03b</a>)</li>
<li><strong>eslint-plugin:</strong> [<code>ban-types</code>] remove <code>object</code> from default options ([<a href="https://github.com/typescript-eslint/typescript-eslint/commit/ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf">ae3fa900d5b4e1f557a52ca58d35a7d098d9efaf</a></li>
<li>remove <code>meta.docs.category</code> from rules (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3800">#3800</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/71c93706e55f5f92a1285102b93c6ab1950c6df4">71c9370</a>)</li>
<li>remove <code>TSParenthesizedType</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3340">#3340</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/c8ee43269faea4c04ec02eaa2b81a0aa6eec5d3e">c8ee432</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3136">#3136</a></li>
<li>support <code>PrivateIdentifier</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3808">#3808</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0eefe5e49d21af3f1e3e2d9a90c2e49929863ac2">0eefe5e</a>), closes <a href="https://github.com/typescript-eslint/typescript-eslint/issues/3430">#3430</a> <a href="https://github.com/typescript-eslint/typescript-eslint/issues/2933">#2933</a></li>
<li><strong>experimental-utils:</strong> extract <code>isNodeOfTypes</code> out of <code>ast-utils</code>' <code>predicates</code> (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3836">#3836</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/0cc509b61df248cfb4b42fe64ec800f3cac69c69">0cc509b</a>)</li>
<li><strong>typescript-estree:</strong> remove legacy <code>useJSXTextNode</code> option (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3109">#3109</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/5b84b98fb3cf68d944b7d4e970f39f4e88f0b2d5">5b84b98</a>)</li>
<li>support ESLint v8 (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3737">#3737</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/4ca62aee6681d706e762a8db727541ca204364f2">4ca62ae</a>)</li>
<li><strong>experimental-utils:</strong> remove <code>getComments</code> from <code>ESLint</code> <code>SourceCode</code> types (<a href="https://github.com/typescript-eslint/typescript-eslint/issues/3766">#3766</a>) (<a href="https://github.com/typescript-eslint/typescript-eslint/commit/165a507970d8e4a0ed12abdd5f0d892f7de83ffe">165a507</a>)</li>
</ul>

</details>


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: